### PR TITLE
feat: expose additional API required for ABI

### DIFF
--- a/schemafy_lib/src/generator.rs
+++ b/schemafy_lib/src/generator.rs
@@ -48,7 +48,7 @@ impl<'a, 'b> Generator<'a, 'b> {
         } else if let Some(input_json) = &self.input_json {
             input_json.clone()
         } else {
-            panic!("Either input file or inpt json should be specified");
+            panic!("Either input file or input json should be specified");
         };
 
         let schema = serde_json::from_str(&json)


### PR DESCRIPTION
Exposes:
* a way to generate Rust code from a JSON string (and not from a file)
* a way to get the resulting Schema object as well as the token stream
* a way to resolve subschemas against `Expander`