### PR TITLE
chore: release 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "schemafy"
-version = "0.6.0" # VERSION_TAG
-authors = ["Markus Westerlind <marwes91@gmail.com>"]
+name = "schemafy-near"
+version = "0.7.0" # VERSION_TAG
+authors = ["Markus Westerlind <marwes91@gmail.com>", "Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 
 description = "Generates serializeable Rust types from a json schema"
 license = "MIT"
 keywords = ["json-schema", "code-generation"]
-repository = "https://github.com/Marwes/schemafy"
-documentation = "https://docs.rs/schemafy"
+repository = "https://github.com/near/schemafy"
+documentation = "https://docs.rs/schemafy-near"
 
 [lib]
 proc-macro = true
@@ -19,7 +19,7 @@ path = "src/generate_tests.rs"
 required-features = ["generate-tests"]
 
 [[bin]]
-name = "schemafy"
+name = "schemafy-near"
 path = "src/main.rs"
 required-features = ["tool"]
 
@@ -27,8 +27,8 @@ required-features = ["tool"]
 
 [dependencies]
 anyhow = { version = "1", optional = true }
-schemafy_core = { version = "0.6.0", path = "schemafy_core" } # VERSION_TAG
-schemafy_lib = { version = "0.6.0", path = "schemafy_lib" }   # VERSION_TAG
+schemafy_core = { version = "0.7.0", path = "schemafy_core", package = "schemafy_near_core" } # VERSION_TAG
+schemafy_lib = { version = "0.7.0", path = "schemafy_lib", package = "schemafy_near_lib" }   # VERSION_TAG
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
@@ -40,8 +40,8 @@ tempfile = { version = "3", optional = true }
 Inflector = "0.11"
 
 [build-dependencies]
-schemafy_core = { version = "0.6.0", path = "schemafy_core" } # VERSION_TAG
-schemafy_lib = { version = "0.6.0", path = "schemafy_lib" }   # VERSION_TAG
+schemafy_core = { version = "0.7.0", path = "schemafy_core", package = "schemafy_near_core" } # VERSION_TAG
+schemafy_lib = { version = "0.7.0", path = "schemafy_lib", package = "schemafy_near_lib" }   # VERSION_TAG
 
 [features]
 internal-regenerate = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "schemafy-near"
+name = "near-schemafy"
 version = "0.7.0" # VERSION_TAG
 authors = ["Markus Westerlind <marwes91@gmail.com>", "Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
@@ -8,7 +8,7 @@ description = "Generates serializeable Rust types from a json schema"
 license = "MIT"
 keywords = ["json-schema", "code-generation"]
 repository = "https://github.com/near/schemafy"
-documentation = "https://docs.rs/schemafy-near"
+documentation = "https://docs.rs/near-schemafy"
 
 [lib]
 proc-macro = true
@@ -19,7 +19,7 @@ path = "src/generate_tests.rs"
 required-features = ["generate-tests"]
 
 [[bin]]
-name = "schemafy-near"
+name = "near-schemafy"
 path = "src/main.rs"
 required-features = ["tool"]
 
@@ -27,8 +27,8 @@ required-features = ["tool"]
 
 [dependencies]
 anyhow = { version = "1", optional = true }
-schemafy_core = { version = "0.7.0", path = "schemafy_core", package = "schemafy_near_core" } # VERSION_TAG
-schemafy_lib = { version = "0.7.0", path = "schemafy_lib", package = "schemafy_near_lib" }   # VERSION_TAG
+schemafy_core = { version = "0.7.0", path = "schemafy_core", package = "near_schemafy_core" } # VERSION_TAG
+schemafy_lib = { version = "0.7.0", path = "schemafy_lib", package = "near_schemafy_lib" }   # VERSION_TAG
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
@@ -40,8 +40,8 @@ tempfile = { version = "3", optional = true }
 Inflector = "0.11"
 
 [build-dependencies]
-schemafy_core = { version = "0.7.0", path = "schemafy_core", package = "schemafy_near_core" } # VERSION_TAG
-schemafy_lib = { version = "0.7.0", path = "schemafy_lib", package = "schemafy_near_lib" }   # VERSION_TAG
+schemafy_core = { version = "0.7.0", path = "schemafy_core", package = "near_schemafy_core" } # VERSION_TAG
+schemafy_lib = { version = "0.7.0", path = "schemafy_lib", package = "near_schemafy_lib" }   # VERSION_TAG
 
 [features]
 internal-regenerate = []

--- a/schemafy_core/Cargo.toml
+++ b/schemafy_core/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "schemafy_core"
-version = "0.6.0" # VERSION_TAG
-authors = ["Markus Westerlind <marwes91@gmail.com>"]
+name = "schemafy_near_core"
+version = "0.7.0" # VERSION_TAG
+authors = ["Markus Westerlind <marwes91@gmail.com>", "Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 
 description = "Generates serializeable Rust types from a json schema"
 license = "MIT"
 
-repository = "https://github.com/Marwes/schemafy"
-documentation = "https://docs.rs/schemafy"
+repository = "https://github.com/near/schemafy"
+documentation = "https://docs.rs/schemafy-near"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/schemafy_core/Cargo.toml
+++ b/schemafy_core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "schemafy_near_core"
+name = "near_schemafy_core"
 version = "0.7.0" # VERSION_TAG
 authors = ["Markus Westerlind <marwes91@gmail.com>", "Near Inc <hello@nearprotocol.com>"]
 edition = "2018"

--- a/schemafy_lib/Cargo.toml
+++ b/schemafy_lib/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
-name = "schemafy_lib"
-version = "0.6.0" # VERSION_TAG
-authors = ["Markus Westerlind <marwes91@gmail.com>", "MATILLAT Quentin <qmatillat@gmail.com>"]
+name = "schemafy_near_lib"
+version = "0.7.0" # VERSION_TAG
+authors = ["Markus Westerlind <marwes91@gmail.com>", "MATILLAT Quentin <qmatillat@gmail.com>", "Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 
 description = "Generates serializeable Rust types from a json schema"
 license = "MIT"
 
-repository = "https://github.com/Marwes/schemafy"
-documentation = "https://docs.rs/schemafy"
+repository = "https://github.com/near/schemafy"
+documentation = "https://docs.rs/schemafy-near"
 
 
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-schemafy_core = { version = "0.6.0", path = "../schemafy_core" } # VERSION_TAG
+schemafy_core = { version = "0.7.0", path = "../schemafy_core", package = "schemafy_near_core" } # VERSION_TAG
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/schemafy_lib/Cargo.toml
+++ b/schemafy_lib/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "schemafy_near_lib"
+name = "near_schemafy_lib"
 version = "0.7.0" # VERSION_TAG
 authors = ["Markus Westerlind <marwes91@gmail.com>", "MATILLAT Quentin <qmatillat@gmail.com>", "Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/schemafy-near"
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-schemafy_core = { version = "0.7.0", path = "../schemafy_core", package = "schemafy_near_core" } # VERSION_TAG
+schemafy_core = { version = "0.7.0", path = "../schemafy_core", package = "near_schemafy_core" } # VERSION_TAG
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
Releasing this library unblocks releasing https://github.com/near/near-abi-rs and https://github.com/near/near-sdk-abi